### PR TITLE
Remove device-manager and webscripts from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ After above steps, your directory structure would be like:
 ├── dist
 │   ├── openwrt
 │   ├── openwrt-ckt-feeds
-|   |       ├── device-manager
 |   |       ├── button-led-controller
 |   |       ├── motion-led-controller
-|   |       ├── relay-gateway
-|   |       └── webscripts
+|   |       └── relay-gateway
 │   └── openwrt-feeds
 |   |       ├── awalwm2m
 |   |       ├── board-test
@@ -37,10 +35,8 @@ After above steps, your directory structure would be like:
     ├── AwaLWM2M
     ├── button-sensor
     ├── motion-sensor
-    ├── device-manager
     ├── button-led-controller
     ├── motion-led-controller
     ├── relay-gateway
-    ├── libobjects
-    └── webscripts
+    └── libobjects
 ```

--- a/default.xml
+++ b/default.xml
@@ -22,6 +22,4 @@
 	<project path="packages/button-led-controller" name="CreatorKit/button-led-controller" revision="dev"/>
 	<project path="packages/motion-led-controller" name="CreatorKit/motion-led-controller" revision="dev"/>
 	<project path="packages/relay-gateway" name="CreatorKit/relay-gateway" revision="dev"/>
-	<project path="packages/device-manager" name="CreatorKit/device-manager" revision="dev"/>
-	<project path="packages/webscripts" name="CreatorKit/webscripts" revision="dev"/>
 </manifest>


### PR DESCRIPTION
Since these packages are no longer actively used in CreatorKit projects, they can be excluded from cloning in using the manifest XMLs